### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/labs64io-ci.yml
+++ b/.github/workflows/labs64io-ci.yml
@@ -8,6 +8,9 @@
 
 name: Labs64.IO - API Gateway - CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]

--- a/.github/workflows/labs64io-ci.yml
+++ b/.github/workflows/labs64io-ci.yml
@@ -10,6 +10,7 @@ name: Labs64.IO - API Gateway - CI
 
 permissions:
   contents: read
+  security-events: write
 
 on:
   push:

--- a/.github/workflows/labs64io-ci.yml
+++ b/.github/workflows/labs64io-ci.yml
@@ -38,4 +38,5 @@ jobs:
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph
+      if: github.event_name == 'push'
       uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/.github/workflows/labs64io-ci.yml
+++ b/.github/workflows/labs64io-ci.yml
@@ -9,7 +9,7 @@
 name: Labs64.IO - API Gateway - CI
 
 permissions:
-  contents: read
+  contents: write
   security-events: write
 
 on:
@@ -38,5 +38,4 @@ jobs:
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph
-      if: github.event_name == 'push'
       uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6


### PR DESCRIPTION
Potential fix for [https://github.com/Labs64/labs64.io-api-gateway/security/code-scanning/2](https://github.com/Labs64/labs64.io-api-gateway/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow involves checking out code and building a project, the `contents: read` permission is sufficient. If additional permissions are required for specific steps, they can be added explicitly.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `build` job to limit permissions to that specific job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
