### PR TITLE
feat(authproxy): complete RFC-03 trusted header contract (X-Auth-Tenant, X-Request-ID)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Traefik ForwardAuth middleware — verifies OIDC/JWT tokens and enforces path-ba
 
 - Deployed as `traefik-authproxy` Helm chart in `labs64io` namespace.
 - Traefik forwards every request to `/auth` before routing to upstream services.
-- On success, sets `X-Auth-User` and `X-Auth-Roles` headers that upstream services trust.
+- On success, emits the full RFC-03 trusted header contract that upstream services trust: `X-Auth-User`, `X-Auth-Roles`, `X-Auth-Tenant` (`-` when tenant-less), `X-Request-ID` (echoed when well-formed, otherwise generated as UUIDv7). All four are set on **every** 2xx (empty when not applicable) so Traefik's `authResponseHeaders` always overwrite client-supplied values. Values are sanitized to `^[a-zA-Z0-9_.:-]+$` (CR/LF stripped) — keep identical to the `l64-auth-context` libraries in `labs64.io-commons`.
 
 ## Repository layout
 
@@ -37,6 +37,7 @@ Traefik ForwardAuth middleware — verifies OIDC/JWT tokens and enforces path-ba
 | `OIDC_REALM` | `default` | OIDC realm |
 | `OIDC_AUDIENCE` | `account` | Expected JWT audience |
 | `TOKEN_ROLES_CLAIM_PATHS` | `realm_access.roles,resource_access.{audience}.roles` | JWT claim paths |
+| `TOKEN_TENANT_CLAIM_PATH` | `tenant` | JWT dot-path for the tenant identifier (`X-Auth-Tenant`) |
 | `ROLE_MAPPING_FILE` | `role_mapping.yaml` | Base role mapping |
 | `ROLE_MAPPING_DIR` | (empty) | Per-module role mapping fragments |
 | `JWKS_CACHE_TTL` | `3600` | JWKS cache TTL (seconds) |

--- a/traefik-authproxy/tests/test_auth_headers.py
+++ b/traefik-authproxy/tests/test_auth_headers.py
@@ -1,0 +1,164 @@
+import sys
+import pathlib
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+import traefik_authproxy
+from traefik_authproxy import app, sanitize_header_value, _uuid7
+
+CONTRACT_HEADERS = ("X-Auth-User", "X-Auth-Roles", "X-Auth-Tenant", "X-Request-ID")
+
+
+# --- sanitize_header_value ---
+
+def test_sanitize_passes_contract_values():
+    assert sanitize_header_value("svc:checkout-be") == "svc:checkout-be"
+    assert sanitize_header_value("t_100.a-b") == "t_100.a-b"
+
+
+def test_sanitize_strips_crlf_and_disallowed_chars():
+    assert sanitize_header_value("jdoe\r\nX-Evil: 1") == "jdoeX-Evil:1"
+    assert sanitize_header_value("a b\tc") == "abc"
+    assert sanitize_header_value(None) == ""
+
+
+# --- _uuid7 ---
+
+def test_uuid7_is_valid_uuid_version_7():
+    value = uuid.UUID(_uuid7())
+    assert value.version == 7
+
+
+# --- /auth endpoint header emission ---
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr(traefik_authproxy, "PROTECTED_PATHS", {"/checkout/api": ["ecommerce-role"]})
+    monkeypatch.setattr(traefik_authproxy, "PUBLIC_PATHS", ["/checkout/v3/api-docs"])
+    return TestClient(app)
+
+
+@pytest.fixture
+def valid_token(monkeypatch):
+    monkeypatch.setattr(traefik_authproxy, "verify_token", lambda token: {
+        "sub": "1234-sub",
+        "preferred_username": "jdoe",
+        "tenant": "t_100",
+        "realm_access": {"roles": ["ecommerce-role"]},
+    })
+
+
+def test_public_path_emits_full_empty_contract(client):
+    response = client.get(
+        "/auth",
+        headers={
+            "X-Forwarded-Uri": "/checkout/v3/api-docs",
+            # spoofing attempt: must be overwritten by the ACS's own values
+            "X-Auth-User": "attacker",
+            "X-Auth-Roles": "admin-role",
+            "X-Auth-Tenant": "t_evil",
+        },
+    )
+    assert response.status_code == 200
+    assert response.headers["X-Auth-User"] == ""
+    assert response.headers["X-Auth-Roles"] == ""
+    assert response.headers["X-Auth-Tenant"] == "-"
+    assert uuid.UUID(response.headers["X-Request-ID"])
+
+
+def test_authenticated_request_emits_identity(client, valid_token):
+    response = client.get(
+        "/auth",
+        headers={"X-Forwarded-Uri": "/checkout/api/v1/customers", "Authorization": "Bearer x"},
+    )
+    assert response.status_code == 200
+    assert response.headers["X-Auth-User"] == "jdoe"
+    assert response.headers["X-Auth-Roles"] == "ecommerce-role"
+    assert response.headers["X-Auth-Tenant"] == "t_100"
+    assert response.headers["X-Request-ID"]
+
+
+def test_preferred_username_falls_back_to_sub(client, monkeypatch):
+    monkeypatch.setattr(traefik_authproxy, "verify_token", lambda token: {
+        "sub": "1234-sub",
+        "realm_access": {"roles": ["ecommerce-role"]},
+    })
+    response = client.get(
+        "/auth",
+        headers={"X-Forwarded-Uri": "/checkout/api/v1/customers", "Authorization": "Bearer x"},
+    )
+    assert response.status_code == 200
+    assert response.headers["X-Auth-User"] == "1234-sub"
+    assert response.headers["X-Auth-Tenant"] == "-"
+
+
+def test_tenantless_token_emits_dash(client, monkeypatch):
+    monkeypatch.setattr(traefik_authproxy, "verify_token", lambda token: {
+        "sub": "1234-sub",
+        "realm_access": {"roles": ["ecommerce-role"]},
+    })
+    response = client.get(
+        "/auth",
+        headers={"X-Forwarded-Uri": "/checkout/api/v1/customers", "Authorization": "Bearer x"},
+    )
+    assert response.headers["X-Auth-Tenant"] == "-"
+
+
+def test_well_formed_inbound_request_id_is_echoed(client, valid_token):
+    response = client.get(
+        "/auth",
+        headers={
+            "X-Forwarded-Uri": "/checkout/api/v1/customers",
+            "Authorization": "Bearer x",
+            "X-Request-ID": "req-abc.123",
+        },
+    )
+    assert response.headers["X-Request-ID"] == "req-abc.123"
+
+
+def test_malformed_inbound_request_id_is_replaced(client, valid_token):
+    response = client.get(
+        "/auth",
+        headers={
+            "X-Forwarded-Uri": "/checkout/api/v1/customers",
+            "Authorization": "Bearer x",
+            "X-Request-ID": "bad value\r\nX-Evil: 1",
+        },
+    )
+    assert response.headers["X-Request-ID"] != "bad value\r\nX-Evil: 1"
+    assert uuid.UUID(response.headers["X-Request-ID"])
+
+
+def test_header_values_are_sanitized(client, monkeypatch):
+    monkeypatch.setattr(traefik_authproxy, "verify_token", lambda token: {
+        "preferred_username": "jdoe\r\nX-Evil: 1",
+        "tenant": "t 100",
+        "realm_access": {"roles": ["ecommerce-role", "bad role"]},
+    })
+    response = client.get(
+        "/auth",
+        headers={"X-Forwarded-Uri": "/checkout/api/v1/customers", "Authorization": "Bearer x"},
+    )
+    assert response.status_code == 200
+    assert "\r" not in response.headers["X-Auth-User"]
+    assert response.headers["X-Auth-Tenant"] == "t100"
+    # every emitted role obeys the value alphabet
+    for role in response.headers["X-Auth-Roles"].split(","):
+        assert role == sanitize_header_value(role)
+
+
+def test_missing_token_on_protected_path_401(client):
+    response = client.get("/auth", headers={"X-Forwarded-Uri": "/checkout/api/v1/customers"})
+    assert response.status_code == 401
+
+
+def test_unmapped_protected_path_fails_closed(client, valid_token):
+    response = client.get(
+        "/auth",
+        headers={"X-Forwarded-Uri": "/unknown/api", "Authorization": "Bearer x"},
+    )
+    assert response.status_code == 403

--- a/traefik-authproxy/tests/test_auth_headers.py
+++ b/traefik-authproxy/tests/test_auth_headers.py
@@ -162,3 +162,16 @@ def test_unmapped_protected_path_fails_closed(client, valid_token):
         headers={"X-Forwarded-Uri": "/unknown/api", "Authorization": "Bearer x"},
     )
     assert response.status_code == 403
+
+
+def test_subjectless_client_token_maps_to_service_principal(client, monkeypatch):
+    monkeypatch.setattr(traefik_authproxy, "verify_token", lambda token: {
+        "azp": "checkout-be",
+        "realm_access": {"roles": ["ecommerce-role"]},
+    })
+    response = client.get(
+        "/auth",
+        headers={"X-Forwarded-Uri": "/checkout/api/v1/customers", "Authorization": "Bearer x"},
+    )
+    assert response.status_code == 200
+    assert response.headers["X-Auth-User"] == "svc:checkout-be"

--- a/traefik-authproxy/tests/test_path_matching.py
+++ b/traefik-authproxy/tests/test_path_matching.py
@@ -1,0 +1,53 @@
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+import traefik_authproxy
+from traefik_authproxy import get_required_roles, is_public_path
+
+
+def test_longest_prefix_wins(monkeypatch):
+    monkeypatch.setattr(
+        traefik_authproxy,
+        "PROTECTED_PATHS",
+        {
+            "/checkout/api": ["ecommerce-role"],
+            "/checkout/api/v1/admin": ["admin-role"],
+        },
+    )
+    assert get_required_roles("/checkout/api/v1/customers") == ["ecommerce-role"]
+    assert get_required_roles("/checkout/api/v1/admin/users") == ["admin-role"]
+
+
+def test_no_match_returns_empty(monkeypatch):
+    monkeypatch.setattr(traefik_authproxy, "PROTECTED_PATHS", {"/checkout/api": ["ecommerce-role"]})
+    assert get_required_roles("/payment-gateway/api/v1/payments") == []
+
+
+def test_prefix_is_plain_string_prefix(monkeypatch):
+    monkeypatch.setattr(traefik_authproxy, "PROTECTED_PATHS", {"/checkout/api": ["ecommerce-role"]})
+    # startswith semantics: sibling paths sharing the string prefix also match
+    assert get_required_roles("/checkout/api-extra") == ["ecommerce-role"]
+
+
+def test_overlapping_prefixes_do_not_depend_on_dict_order(monkeypatch):
+    roles_short_first = {"/a": ["short-role"], "/a/b": ["long-role"]}
+    roles_long_first = {"/a/b": ["long-role"], "/a": ["short-role"]}
+    for mapping in (roles_short_first, roles_long_first):
+        monkeypatch.setattr(traefik_authproxy, "PROTECTED_PATHS", mapping)
+        assert get_required_roles("/a/b/c") == ["long-role"]
+        assert get_required_roles("/a/x") == ["short-role"]
+
+
+def test_public_path_prefix_matching(monkeypatch):
+    monkeypatch.setattr(traefik_authproxy, "PUBLIC_PATHS", ["/checkout/v3/api-docs", "/health"])
+    assert is_public_path("/checkout/v3/api-docs")
+    assert is_public_path("/checkout/v3/api-docs/swagger-config")
+    assert is_public_path("/health")
+    assert not is_public_path("/checkout/api/v1/customers")
+
+
+def test_no_public_paths(monkeypatch):
+    monkeypatch.setattr(traefik_authproxy, "PUBLIC_PATHS", [])
+    assert not is_public_path("/anything")

--- a/traefik-authproxy/traefik_authproxy.py
+++ b/traefik-authproxy/traefik_authproxy.py
@@ -400,6 +400,11 @@ async def authenticate(request: Request):
         raise HTTPException(status_code=403, detail=f"Insufficient roles. Required: {required_roles}")
 
     user_id = payload.get("preferred_username") or payload.get("sub")
+    if not user_id:
+        # Client-credentials token without a subject: map the client to a
+        # service principal (RFC-03: X-Auth-User: svc:<name>).
+        client = payload.get("azp") or payload.get("client_id")
+        user_id = f"svc:{client}" if client else None
     tenant = _resolve_claim_path(payload, TOKEN_TENANT_CLAIM_PATH) if TOKEN_TENANT_CLAIM_PATH else None
     app_logger.info(f"Access granted to user {user_id} for path {forwarded_uri}")
 

--- a/traefik-authproxy/traefik_authproxy.py
+++ b/traefik-authproxy/traefik_authproxy.py
@@ -1,4 +1,6 @@
 import os
+import re
+import secrets
 import time
 import uuid
 import logging
@@ -34,6 +36,8 @@ TOKEN_ROLES_CLAIM_PATHS = os.getenv(
     "TOKEN_ROLES_CLAIM_PATHS",
     "realm_access.roles,resource_access.{audience}.roles",
 )
+# Dot-path into the JWT payload for the tenant identifier (RFC-03 header contract).
+TOKEN_TENANT_CLAIM_PATH = os.getenv("TOKEN_TENANT_CLAIM_PATH", "tenant")
 ROLE_MAPPING_FILE = os.getenv("ROLE_MAPPING_FILE", "role_mapping.yaml")
 # Directory with per-module role-mapping fragments (e.g. populated by a
 # k8s-sidecar from labeled ConfigMaps); merged on top of ROLE_MAPPING_FILE.
@@ -51,6 +55,67 @@ numeric_level = getattr(logging, LOG_LEVEL, logging.INFO)
 logging.basicConfig(level=numeric_level, format=LOG_FORMAT)
 app_logger = logging.getLogger("traefik_authproxy")
 app_logger.setLevel(numeric_level)
+
+# --- Trusted header contract (RFC-03) ---
+# Every 2xx from /auth carries the full set (empty / "-" when not applicable),
+# so Traefik's authResponseHeaders always overwrite anything a client sent.
+HEADER_AUTH_USER = "X-Auth-User"
+HEADER_AUTH_ROLES = "X-Auth-Roles"
+HEADER_AUTH_TENANT = "X-Auth-Tenant"
+HEADER_REQUEST_ID = "X-Request-ID"
+TENANT_NONE = "-"
+
+# Allowed characters for emitted header values; everything else (incl. CR/LF)
+# is stripped. Keep identical to the l64-auth-context libraries.
+_HEADER_VALUE_ALLOWED = re.compile(r"[^a-zA-Z0-9_.:-]")
+_HEADER_VALUE_PATTERN = re.compile(r"[a-zA-Z0-9_.:-]+")
+
+
+def sanitize_header_value(value: Any) -> str:
+    """Strip everything outside the contract's value alphabet (incl. CR/LF)."""
+    if value is None:
+        return ""
+    return _HEADER_VALUE_ALLOWED.sub("", str(value))
+
+
+def _uuid7() -> str:
+    """UUIDv7 (time-ordered); stdlib on Python >= 3.14, manual fallback below."""
+    if hasattr(uuid, "uuid7"):
+        return str(uuid.uuid7())
+    timestamp_ms = time.time_ns() // 1_000_000
+    rand_a = secrets.randbits(12)
+    rand_b = secrets.randbits(62)
+    value = (timestamp_ms & 0xFFFFFFFFFFFF) << 80
+    value |= 0x7 << 76
+    value |= rand_a << 64
+    value |= 0b10 << 62
+    value |= rand_b
+    return str(uuid.UUID(int=value))
+
+
+def resolve_request_id(request: Request) -> str:
+    """Echo a well-formed inbound X-Request-ID; generate a UUIDv7 otherwise."""
+    inbound = request.headers.get(HEADER_REQUEST_ID, "")
+    if inbound and _HEADER_VALUE_PATTERN.fullmatch(inbound):
+        return inbound
+    return _uuid7()
+
+
+def set_auth_headers(
+    response: JSONResponse,
+    request_id: str,
+    user_id: str = "",
+    roles: Optional[List[str]] = None,
+    tenant: Optional[str] = None,
+) -> JSONResponse:
+    """Emit the complete trusted header set on a 2xx /auth response."""
+    sanitized_roles = [r for r in (sanitize_header_value(role) for role in (roles or [])) if r]
+    sanitized_tenant = sanitize_header_value(tenant)
+    response.headers[HEADER_AUTH_USER] = sanitize_header_value(user_id)
+    response.headers[HEADER_AUTH_ROLES] = ",".join(sanitized_roles)
+    response.headers[HEADER_AUTH_TENANT] = sanitized_tenant if sanitized_tenant else TENANT_NONE
+    response.headers[HEADER_REQUEST_ID] = request_id
+    return response
 
 # --- Response Models ---
 class AuthResponse(BaseModel):
@@ -298,17 +363,23 @@ async def authenticate(request: Request):
     """Authenticate and authorize a request forwarded by Traefik.
 
     Validates the JWT token from the Authorization header, extracts user roles,
-    and checks them against the configured path/role mapping. On success, the
-    response includes headers that Traefik can forward to upstream services:
-    - X-Auth-User: the subject (sub) claim from the JWT
-    - X-Auth-Roles: comma-separated list of roles
+    and checks them against the configured path/role mapping. Every 2xx response
+    carries the full RFC-03 trusted header set (empty / "-" when not applicable)
+    so Traefik's authResponseHeaders always overwrite client-supplied values:
+    - X-Auth-User: preferred_username | sub claim from the JWT
+    - X-Auth-Roles: comma-separated list of roles (may be empty)
+    - X-Auth-Tenant: tenant claim ("-" for tenant-less calls)
+    - X-Request-ID: echoed if well-formed, otherwise generated (UUIDv7)
     """
     forwarded_uri = request.headers.get("X-Forwarded-Uri", "/")
     app_logger.debug(f"Received request on forwarded URI: {forwarded_uri}")
 
+    request_id = resolve_request_id(request)
+
     if is_public_path(forwarded_uri):
         app_logger.info(f"Public access granted to: {forwarded_uri}")
-        return AuthResponse(message="Public access granted")
+        response = JSONResponse(content=AuthResponse(message="Public access granted").model_dump())
+        return set_auth_headers(response, request_id)
 
     auth_header = request.headers.get("Authorization")
     if not auth_header or not auth_header.startswith("Bearer "):
@@ -328,7 +399,8 @@ async def authenticate(request: Request):
     if not set(user_roles).intersection(required_roles):
         raise HTTPException(status_code=403, detail=f"Insufficient roles. Required: {required_roles}")
 
-    user_id = payload.get("sub")
+    user_id = payload.get("preferred_username") or payload.get("sub")
+    tenant = _resolve_claim_path(payload, TOKEN_TENANT_CLAIM_PATH) if TOKEN_TENANT_CLAIM_PATH else None
     app_logger.info(f"Access granted to user {user_id} for path {forwarded_uri}")
 
     # Return identity headers that Traefik can forward to upstream services
@@ -339,7 +411,4 @@ async def authenticate(request: Request):
             roles=user_roles,
         ).model_dump()
     )
-    response.headers["X-Auth-User"] = user_id or ""
-    response.headers["X-Auth-Roles"] = ",".join(user_roles)
-
-    return response
+    return set_auth_headers(response, request_id, user_id=user_id, roles=user_roles, tenant=tenant)

--- a/traefik-authproxy/traefik_authproxy.py
+++ b/traefik-authproxy/traefik_authproxy.py
@@ -96,7 +96,7 @@ def _uuid7() -> str:
 def resolve_request_id(request: Request) -> str:
     """Echo a well-formed inbound X-Request-ID; generate a UUIDv7 otherwise."""
     inbound = request.headers.get(HEADER_REQUEST_ID, "")
-    if inbound and _HEADER_VALUE_PATTERN.fullmatch(inbound):
+    if inbound and len(inbound) <= 128 and _HEADER_VALUE_PATTERN.fullmatch(inbound):
         return inbound
     return _uuid7()
 
@@ -109,7 +109,7 @@ def set_auth_headers(
     tenant: Optional[str] = None,
 ) -> JSONResponse:
     """Emit the complete trusted header set on a 2xx /auth response."""
-    sanitized_roles = [r for r in (sanitize_header_value(role) for role in (roles or [])) if r]
+    sanitized_roles = sorted(r for r in (sanitize_header_value(role) for role in (roles or [])) if r)
     sanitized_tenant = sanitize_header_value(tenant)
     response.headers[HEADER_AUTH_USER] = sanitize_header_value(user_id)
     response.headers[HEADER_AUTH_ROLES] = ",".join(sanitized_roles)


### PR DESCRIPTION
## What

Completes the RFC-03 trusted header contract in traefik-authproxy. Today the proxy emits only `X-Auth-User` + `X-Auth-Roles`; this adds the missing half and hardens emission:

- **`X-Auth-Tenant`** — extracted from the JWT via new `TOKEN_TENANT_CLAIM_PATH` env (default `tenant`); `-` for tenant-less calls
- **`X-Request-ID`** — inbound value echoed when well-formed, otherwise generated (UUIDv7; stdlib on Python ≥ 3.14, manual fallback otherwise)
- **`X-Auth-User`** now sources `preferred_username | sub` per the RFC contract table
- **Every 2xx carries all four headers** (empty / `-` when not applicable) — including public paths — so Traefik's `authResponseHeaders` always overwrite anything a client sent (RFC-03 spoofing-prevention layer 1)
- **Value sanitization** to `^[a-zA-Z0-9_.:-]+$` with CR/LF stripping, identical to the `l64-auth-context` libraries in `labs64.io-commons`

## Tests

- `tests/test_auth_headers.py` (new): full-contract emission on public + authenticated paths, spoofing overwrite, sanitization (CRLF injection), request-id echo/replace, fail-closed unmapped path
- `tests/test_path_matching.py` (new): closes the coverage gap on `get_required_roles` longest-prefix matching and `is_public_path` — previously the security-critical decision had no tests
- 28/28 passing locally

## Related

- RFC-03 (labs64.io-docs-internal PR #7) — this is the phase 1–2 gateway work
- Companion PRs: labs64.io-helm-charts (authResponseHeaders + edge X-Auth-* strip), labs64.io-commons (consumer libraries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtSifySfrDTqdFEPCs8pq2